### PR TITLE
Don't pass invalid NODE_OPTIONS to worker

### DIFF
--- a/source/threads-worker.js
+++ b/source/threads-worker.js
@@ -32,7 +32,6 @@ class ThreadsWorker {
     const lock = IS_PRODUCTION ? {} : new Lock()
 
     const worker = new Worker(WORKER_FILE, {
-      execArgv: process.env.NODE_OPTIONS?.split(' '),
       workerData: {
         workerRunningSemaphore: lock.semaphore,
         ...this.#workerData,

--- a/tests/loaders.test.js
+++ b/tests/loaders.test.js
@@ -27,15 +27,19 @@ async function run({type}) {
     )
     await fs.writeFile(
       file,
-      `
-      import print from ${JSON.stringify(module.href)}
-      console.log(JSON.stringify(print(), undefined, 2))
-    `,
+      /* Indent */ `
+        import print from ${JSON.stringify(module.href)}
+        console.log(JSON.stringify(print(), undefined, 2))
+      `,
     )
 
     return await execaCommand('yarn node foo.mjs --silent', {
       cwd: directory,
-      env: {FORCE_COLOR: '0'},
+      env: {
+        FORCE_COLOR: '0',
+        // https://github.com/fisker/make-synchronized/pull/44
+        NODE_OPTIONS: '--max-old-space-size=4096',
+      },
     })
   } finally {
     await fs.rm(directory, {force: true, recursive: true})


### PR DESCRIPTION
This was causing downstream projects like prettier-synchronized to break when encountering V8 options like `--max-old-space-size`.

The option itself shouldn't be needed since execArgv values are inherited from the parent thread by default.

See: https://nodejs.org/api/worker_threads.html#new-workerfilename-options

Related: https://github.com/webpack/webpack/issues/14859